### PR TITLE
role 자료형 변경과 로그인 서버에러 수정

### DIFF
--- a/BE/teamgu/src/main/java/com/teamgu/api/controller/JwtAuthController.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/controller/JwtAuthController.java
@@ -1,5 +1,7 @@
 package com.teamgu.api.controller;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -35,11 +37,13 @@ public class JwtAuthController {
 	@Autowired
 	private PasswordEncoder passwordEncoder;
 	
+	Logger logger = LoggerFactory.getLogger(JwtAuthController.class);
+	
 	@PostMapping("/dummyData")
 	@ApiOperation(value = "더미 데이터 추가", notes = "사용자 초기정보(email/pwd/name/role)를 추가 한다") 
 	public ResponseEntity<BaseResDto> signIn(
 			@RequestBody @ApiParam(value = "더미 데이터 추가 (email,pw)", required = true) DummyReqDto dummyReq) {
-		System.out.println("aa");
+		
 		String email = dummyReq.getEmail();
 		String password = dummyReq.getPassword();
 		String name = dummyReq.getName();
@@ -66,8 +70,11 @@ public class JwtAuthController {
         @ApiResponse(code = 500, message = "서버 오류", response = BaseResDto.class)
     })
 	public ResponseEntity<LoginResDto> login(@RequestBody @ApiParam(value = "로그인 정보(email,pw)", required = true) LoginReqDto loginReq) {
+		
 		String email = loginReq.getEmail();
 		String password = loginReq.getPassword();
+		logger.info("email: "+email+" password: "+password);
+		
 		User user = userService.getUserByEmail(email).get();
 		if(passwordEncoder.matches(password, user.getPassword())) {
 			return ResponseEntity.ok(userService.login(loginReq, user));

--- a/BE/teamgu/src/main/java/com/teamgu/api/controller/JwtAuthController.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/controller/JwtAuthController.java
@@ -1,5 +1,7 @@
 package com.teamgu.api.controller;
 
+import java.util.Optional;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -75,11 +77,14 @@ public class JwtAuthController {
 		String password = loginReq.getPassword();
 		logger.info("email: "+email+" password: "+password);
 		
-		User user = userService.getUserByEmail(email).get();
-		if(passwordEncoder.matches(password, user.getPassword())) {
-			return ResponseEntity.ok(userService.login(loginReq, user));
+		Optional<User> opuser = userService.getUserByEmail(email);
+		if(opuser.isPresent()) {		
+			User user = opuser.get();		
+			if(passwordEncoder.matches(password, user.getPassword())) {
+				return ResponseEntity.ok(userService.login(loginReq, user));
+			}	
 		}
-		return ResponseEntity.status(404).body(new LoginResDto(404,"Invalid Password",null,null,null)); 
+		return ResponseEntity.status(404).body(new LoginResDto(404,"Invalid account",null,null,null)); 
 	}
 	
 	@GetMapping("/reissue")

--- a/BE/teamgu/src/main/java/com/teamgu/api/dto/req/DummyReqDto.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/dto/req/DummyReqDto.java
@@ -14,6 +14,6 @@ public class DummyReqDto {
 	String password;
 	@ApiModelProperty(name = "name", example = "팀구")
 	String name;
-	@ApiModelProperty(name = "role", example = "1 : student")
+	@ApiModelProperty(name = "role", example = "1")
 	short role;
 }

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/UserServiceImpl.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/UserServiceImpl.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -48,7 +50,6 @@ public class UserServiceImpl implements UserService {
 	PasswordEncoder passwordEncoder;
 
 	@Autowired
-
 	UserRepository userRepository;
 	
 	@Autowired
@@ -73,10 +74,18 @@ public class UserServiceImpl implements UserService {
 
 	@Autowired
 	JwtUserDetailsService userDetailsService;
-
+	
+	Logger logger = LoggerFactory.getLogger(UserServiceImpl.class);
+	
 	@Override
 	public Optional<User> getUserByEmail(String email) {
+		logger.info(email);
 		Optional<User> user = userRepository.findByEmail(email);
+		if(user.isPresent()) {//Optional의 null 체크(값ㅇ ㅣ있는 경우)
+			logger.info(user.get().getEmail());			
+		}else {//없는 경우
+			logger.info("user가 비었습니다.");
+		}
 		return user;
 	}
 


### PR DESCRIPTION
## role 자료형 변경
이전 버전의 role은 String 자료형이었고 DummyData 삽입 과정에서 String 형태의 example을 삽입하는 구조였습니다.
```
example = "1 : student"
```

하지만 role이 `short`로 변경되면서 미처 변경하지 못했던 example을 `short` 자료형에 맞게 변경했습니다.

## 로그인 서버 에러 수정
초기에 의도한 것은 email/password가 틀리는 경우 404 Error를 반환하는 것입니다.
하지만 의도와 달리 password만 틀리는 경우 404 에러를 반환했고
이메일이 없는 경우 null값 참조가 일어나면서 생기는 500에러를 Null값 검증으로 해결했습니다.